### PR TITLE
Treat "No files found are eligible for import" as stalled.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,4 @@ STALLED_ACTION=BLOCKLIST_AND_SEARCH            # Options: REMOVE or BLOCKLIST or
 VERBOSE=false                                  # Enable verbose/debug logging
 RUN_INTERVAL=300                               # How often should the script be run (in seconds)
 COUNT_DOWNLOADING_METADATA_AS_STALLED=false    # If it should count downloads with the "Downloading Metadata" as stalled
+COUNT_IMPORT_FAILURE_AS_STALLED=false          # If downloads that fail to import into a client should be marked as stalled

--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,5 @@ VERBOSE=false                                  # Enable verbose/debug logging
 RUN_INTERVAL=300                               # How often should the script be run (in seconds)
 COUNT_DOWNLOADING_METADATA_AS_STALLED=false    # If it should count downloads with the "Downloading Metadata" as stalled
 COUNT_IMPORT_FAILURE_AS_STALLED=false          # If downloads that fail to import into a client should be marked as stalled
+DOWNLOADING_METADATA_TIMEOUT=3600              # Override the time for this to be considered stalled
+IMPORT_FAILURE_TIMEOUT=3600                    # Override the time for this to be considered stalled

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ The script is fully configurable using environment variables specified in a `.en
 | `VERBOSE`                               | Enable verbose logging for debugging (`true` or `false`).                                       | `false`                |
 | `RUN_INTERVAL`                          | Time (in seconds) between script executions when running in Docker.                             | `300` (5 minutes)      |
 | `COUNT_DOWNLOADING_METADATA_AS_STALLED` | Whether the script should count downloads with the status of "Downloading Metadata" as stalled. | `false`                |
+| `DOWNLOADING_METADATA_TIMEOUT`          | Time (in seconds) stalled metadata must remain stalled before actions are taken.                | `STALLED_TIMEOUT`      |
 | `COUNT_IMPORT_FAILURE_AS_STALLED`       | Handle "No files found are eligible for import" in clients as stalled.                          | `false`                |
+| `IMPORT_FAILURE_TIMEOUT`                | Time (in seconds) a failed import must remain stalled before actions are taken.                 | `STALLED_TIMEOUT`      |
 
 To disable Radarr or Sonarr; leave the URL empty in the environment. If the service does not have a URL, then it is skipped. Multple services are allowed by using comma seperated values.
 
@@ -129,6 +131,8 @@ services:
       RUN_INTERVAL: "300"
       COUNT_DOWNLOADING_METADATA_AS_STALLED: "false"
       COUNT_IMPORT_FAILURE_AS_STALLED: "false"
+      DOWNLOADING_METADATA_TIMEOUT: "1800"
+      IMPORT_FAILURE_TIMEOUT: "900"
 ```
 
 **Docker CLI**
@@ -153,13 +157,15 @@ docker run -d \
   -e RUN_INTERVAL=300 \
   -e COUNT_DOWNLOADING_METADATA_AS_STALLED=false \
   -e COUNT_IMPORT_FAILURE_AS_STALLED=false \
+  -e DOWNLOADING_METADATA_TIMEOUT: "1800" \
+  -e IMPORT_FAILURE_TIMEOUT: "900" \
   --restart unless-stopped \
   tommythebeast/arrstalledhandler:latest
 ```
 
 *One line:*
 ``` bash
-docker run -d --name=ArrStalledHandler -e RADARR_URL=http://localhost:7878,http://otherhost:7878 -e RADARR_API_KEY=your_radarr_api_key,your_2nd_radarr_api_key -e SONARR_URL=http://localhost:8989,http://otherhost:8989 -e SONARR_API_KEY=your_sonarr_api_key,your_2nd_sonarr_api_key -e LIDARR_URL=http://localhost:8686,http://otherhost:8686  -e LIDARR_API_KEY=your_lidarr_api_key,your_2nd_lidarr_api_key -e READARR_URL=http://localhost:8787,http://otherhost:8787 -e READARR_API_KEY=your_readarr_api_key,our_2nd_readarr_api_key -e STALLED_TIMEOUT=3600 -e STALLED_ACTION=BLOCKLIST_AND_SEARCH -e VERBOSE=false -e RUN_INTERVAL=300 -e COUNT_DOWNLOADING_METADATA_AS_STALLED=false -e COUNT_IMPORT_FAILURE_AS_STALLED=false --restart unless-stopped tommythebeast/arrstalledhandler:latest
+docker run -d --name=ArrStalledHandler -e RADARR_URL=http://localhost:7878,http://otherhost:7878 -e RADARR_API_KEY=your_radarr_api_key,your_2nd_radarr_api_key -e SONARR_URL=http://localhost:8989,http://otherhost:8989 -e SONARR_API_KEY=your_sonarr_api_key,your_2nd_sonarr_api_key -e LIDARR_URL=http://localhost:8686,http://otherhost:8686  -e LIDARR_API_KEY=your_lidarr_api_key,your_2nd_lidarr_api_key -e READARR_URL=http://localhost:8787,http://otherhost:8787 -e READARR_API_KEY=your_readarr_api_key,our_2nd_readarr_api_key -e STALLED_TIMEOUT=3600 -e STALLED_ACTION=BLOCKLIST_AND_SEARCH -e VERBOSE=false -e RUN_INTERVAL=300 -e COUNT_DOWNLOADING_METADATA_AS_STALLED=false -e COUNT_IMPORT_FAILURE_AS_STALLED=false -e DOWNLOADING_METADATA_TIMEOUT=1800 -e IMPORT_FAILURE_TIMEOUT=900 --restart unless-stopped tommythebeast/arrstalledhandler:latest
 ```
 
 ### Docker Deployment (Manual)
@@ -190,6 +196,8 @@ docker run -d --name=ArrStalledHandler -e RADARR_URL=http://localhost:7878,http:
     RUN_INTERVAL=300
     COUNT_DOWNLOADING_METADATA_AS_STALLED=false
     COUNT_IMPORT_FAILURE_AS_STALLED=false
+    DOWNLOADING_METADATA_TIMEOUT=1800
+    IMPORT_FAILURE_TIMEOUT=900
     ```
 
 3.  **Build the Docker Image**:
@@ -239,6 +247,8 @@ docker run -d --name=ArrStalledHandler -e RADARR_URL=http://localhost:7878,http:
     RUN_INTERVAL=300
     COUNT_DOWNLOADING_METADATA_AS_STALLED=false
     COUNT_IMPORT_FAILURE_AS_STALLED=false
+    DOWNLOADING_METADATA_TIMEOUT=1800
+    IMPORT_FAILURE_TIMEOUT=900
     ```
         
 4.  **Run the Script**:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This project is available on [GitHub](https://github.com/tommyvange/ArrStalledHa
 -   **Automatic Handling of Stalled Downloads**:
     -   Detect stalled downloads based on error messages from Radarr/Sonarr/Lidarr/Readarr queues.
     - Detect download stuck on "Downloading Metadata" in qBittorrent and treat them as stalled.
+    - Detect downloads that complete with "No files found are eligible for import" in clients, treat them as stalled.
     -   Perform configurable actions such as:
         -   Remove the stalled download.
         -   Blocklist the stalled download.
@@ -52,7 +53,8 @@ The script is fully configurable using environment variables specified in a `.en
 | `STALLED_ACTION`                        | Action to perform on stalled downloads: `REMOVE`, `BLOCKLIST`, or `BLOCKLIST_AND_SEARCH`.       | `BLOCKLIST_AND_SEARCH` |
 | `VERBOSE`                               | Enable verbose logging for debugging (`true` or `false`).                                       | `false`                |
 | `RUN_INTERVAL`                          | Time (in seconds) between script executions when running in Docker.                             | `300` (5 minutes)      |
-| `COUNT_DOWNLOADING_METADATA_AS_STALLED` | Weather the script should count downloads with the status of "Downloading Metadata" as stalled. | `false`                |
+| `COUNT_DOWNLOADING_METADATA_AS_STALLED` | Whether the script should count downloads with the status of "Downloading Metadata" as stalled. | `false`                |
+| `COUNT_IMPORT_FAILURE_AS_STALLED`       | Handle "No files found are eligible for import" in clients as stalled.                          | `false`                |
 
 To disable Radarr or Sonarr; leave the URL empty in the environment. If the service does not have a URL, then it is skipped. Multple services are allowed by using comma seperated values.
 
@@ -70,6 +72,7 @@ To disable Radarr or Sonarr; leave the URL empty in the environment. If the serv
     
     -   The script identifies stalled downloads based on the error message: `"The download is stalled with no connections"`.
     -   [Optional] The script treats downloads with the error message `"qBittorrent is downloading metadata"` as stalled.
+    -   [Optional] Downloaded - Waiting to Import with client message: `"No files found are eligible for import"` treated as stalled. 
 3.  **Timeout Check**:
     
     -   Downloads are only handled if they have been stalled longer than the configured `STALLED_TIMEOUT`.
@@ -125,6 +128,7 @@ services:
       VERBOSE: "false"
       RUN_INTERVAL: "300"
       COUNT_DOWNLOADING_METADATA_AS_STALLED: "false"
+      COUNT_IMPORT_FAILURE_AS_STALLED: "false"
 ```
 
 **Docker CLI**
@@ -148,13 +152,14 @@ docker run -d \
   -e VERBOSE=false \
   -e RUN_INTERVAL=300 \
   -e COUNT_DOWNLOADING_METADATA_AS_STALLED=false \
+  -e COUNT_IMPORT_FAILURE_AS_STALLED=false \
   --restart unless-stopped \
   tommythebeast/arrstalledhandler:latest
 ```
 
 *One line:*
 ``` bash
-docker run -d --name=ArrStalledHandler -e RADARR_URL=http://localhost:7878,http://otherhost:7878 -e RADARR_API_KEY=your_radarr_api_key,your_2nd_radarr_api_key -e SONARR_URL=http://localhost:8989,http://otherhost:8989 -e SONARR_API_KEY=your_sonarr_api_key,your_2nd_sonarr_api_key -e LIDARR_URL=http://localhost:8686,http://otherhost:8686  -e LIDARR_API_KEY=your_lidarr_api_key,your_2nd_lidarr_api_key -e READARR_URL=http://localhost:8787,http://otherhost:8787 -e READARR_API_KEY=your_readarr_api_key,our_2nd_readarr_api_key -e STALLED_TIMEOUT=3600 -e STALLED_ACTION=BLOCKLIST_AND_SEARCH -e VERBOSE=false -e RUN_INTERVAL=300 -e COUNT_DOWNLOADING_METADATA_AS_STALLED=false --restart unless-stopped tommythebeast/arrstalledhandler:latest
+docker run -d --name=ArrStalledHandler -e RADARR_URL=http://localhost:7878,http://otherhost:7878 -e RADARR_API_KEY=your_radarr_api_key,your_2nd_radarr_api_key -e SONARR_URL=http://localhost:8989,http://otherhost:8989 -e SONARR_API_KEY=your_sonarr_api_key,your_2nd_sonarr_api_key -e LIDARR_URL=http://localhost:8686,http://otherhost:8686  -e LIDARR_API_KEY=your_lidarr_api_key,your_2nd_lidarr_api_key -e READARR_URL=http://localhost:8787,http://otherhost:8787 -e READARR_API_KEY=your_readarr_api_key,our_2nd_readarr_api_key -e STALLED_TIMEOUT=3600 -e STALLED_ACTION=BLOCKLIST_AND_SEARCH -e VERBOSE=false -e RUN_INTERVAL=300 -e COUNT_DOWNLOADING_METADATA_AS_STALLED=false -e COUNT_IMPORT_FAILURE_AS_STALLED=false --restart unless-stopped tommythebeast/arrstalledhandler:latest
 ```
 
 ### Docker Deployment (Manual)
@@ -184,6 +189,7 @@ docker run -d --name=ArrStalledHandler -e RADARR_URL=http://localhost:7878,http:
     VERBOSE=false
     RUN_INTERVAL=300
     COUNT_DOWNLOADING_METADATA_AS_STALLED=false
+    COUNT_IMPORT_FAILURE_AS_STALLED=false
     ```
 
 3.  **Build the Docker Image**:
@@ -232,6 +238,7 @@ docker run -d --name=ArrStalledHandler -e RADARR_URL=http://localhost:7878,http:
     VERBOSE=false
     RUN_INTERVAL=300
     COUNT_DOWNLOADING_METADATA_AS_STALLED=false
+    COUNT_IMPORT_FAILURE_AS_STALLED=false
     ```
         
 4.  **Run the Script**:

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,3 +17,4 @@ services:
       VERBOSE: "${VERBOSE}" # Enable verbose/debug logging
       RUN_INTERVAL: "${RUN_INTERVAL}" # How often should the script be run (in seconds)
       COUNT_DOWNLOADING_METADATA_AS_STALLED: "${COUNT_DOWNLOADING_METADATA_AS_STALLED}" # If it should count downloads with the "Downloading Metadata" as stalled
+      COUNT_IMPORT_FAILURE_AS_STALLED: "${COUNT_IMPORT_FAILURE_AS_STALLED}" # If downloads that fail to import into a client should be marked as stalled

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,4 +17,6 @@ services:
       VERBOSE: "${VERBOSE}" # Enable verbose/debug logging
       RUN_INTERVAL: "${RUN_INTERVAL}" # How often should the script be run (in seconds)
       COUNT_DOWNLOADING_METADATA_AS_STALLED: "${COUNT_DOWNLOADING_METADATA_AS_STALLED}" # If it should count downloads with the "Downloading Metadata" as stalled
-      COUNT_IMPORT_FAILURE_AS_STALLED: "${COUNT_IMPORT_FAILURE_AS_STALLED}" # If downloads that fail to import into a client should be marked as stalled
+      COUNT_IMPORT_FAILURE_AS_STALLED: "${COUNT_IMPORT_FAILURE_AS_STALLED}"             # If downloads that fail to import into a client should be marked as stalled
+      DOWNLOADING_METADATA_TIMEOUT: "${DOWNLOADING_METADATA_TIMEOUT}"                   # Override the time for this to be considered stalled
+      IMPORT_FAILURE_TIMEOUT: "${IMPORT_FAILURE_TIMEOUT}"                               # Override the time for this to be considered stalled

--- a/main.py
+++ b/main.py
@@ -313,6 +313,11 @@ def handle_stalled_downloads(base_url, api_key, service_name, api_version):
             download_id = str(item["id"])
             movie_id = item.get("movieId") if service_name == "Radarr" else None
             episode_ids = [item["episodeId"]] if service_name == "Sonarr" and "episodeId" in item else None
+            
+            if is_import_failed_state:
+                reason_str = "failed import"
+            else:
+                reason_str = "stalled"
 
             if download_id in stalled_downloads:
                 first_detected = stalled_downloads[download_id]
@@ -320,14 +325,14 @@ def handle_stalled_downloads(base_url, api_key, service_name, api_version):
 
                 logging.debug(f"Download ID {download_id} first detected: {first_detected}, elapsed: {elapsed_time} seconds.")
                 if elapsed_time > STALLED_TIMEOUT:
-                    logging.info(f"Handling stalled Download ID {download_id} in {service_name} (elapsed time: {elapsed_time} seconds).")
+                    logging.info(f"Handling {reason_str} Download ID {download_id} in {service_name} (elapsed time: {elapsed_time} seconds).")
                     perform_action(base_url, headers, download_id, movie_id, service_name, api_version, episode_ids)
                     remove_stalled_download_from_db(download_id, service_name)
                 else:
-                    logging.info(f"Download ID {download_id} in {service_name} is stalled but within timeout period ({elapsed_time} seconds).")
+                    logging.info(f"Download ID {download_id} in {service_name} is {reason_str} but within timeout period ({elapsed_time} seconds).")
             else:
                 add_stalled_download_to_db(download_id, datetime.now(timezone.utc), service_name)
-                logging.info(f"Adding stalled download ID {download_id} in {service_name} to the database.")
+                logging.info(f"Adding {reason_str} download ID {download_id} in {service_name} to the database.")
 
 if __name__ == "__main__":
     try:

--- a/main.py
+++ b/main.py
@@ -92,6 +92,33 @@ logging.basicConfig(
     handlers=[logging.StreamHandler()]
 )
 
+def log_env_vars():
+    """Log the current environment configuration for debugging."""
+    env_vars = {
+        "RADARR_URL": RADARR_URL,
+        "RADARR_API_KEY": RADARR_API_KEY,
+        "SONARR_URL": SONARR_URL,
+        "SONARR_API_KEY": SONARR_API_KEY,
+        "LIDARR_URL": LIDARR_URL,
+        "LIDARR_API_KEY": LIDARR_API_KEY,
+        "READARR_URL": READARR_URL,
+        "READARR_API_KEY": READARR_API_KEY,
+        "DB_FILE": DB_FILE,
+        "VERBOSE": VERBOSE,
+        "RUN_INTERVAL": RUN_INTERVAL,
+        "STALLED_TIMEOUT": STALLED_TIMEOUT,
+        "STALLED_ACTION": STALLED_ACTION,
+        "COUNT_DOWNLOADING_METADATA_AS_STALLED": COUNT_DOWNLOADING_METADATA_AS_STALLED,
+        "DOWNLOADING_METADATA_TIMEOUT": DOWNLOADING_METADATA_TIMEOUT,
+        "COUNT_IMPORT_FAILURE_AS_STALLED": COUNT_IMPORT_FAILURE_AS_STALLED,
+        "IMPORT_FAILURE_TIMEOUT": IMPORT_FAILURE_TIMEOUT
+    }
+
+    logging.debug("Current runtime configuration:")
+    for key, value in env_vars.items():
+        logging.debug(f"  {key}: {value}")
+
+
 def initialize_database():
     """Initialize the SQLite database for tracking stalled downloads."""
     if STALLED_TIMEOUT == 0:
@@ -423,7 +450,9 @@ def process_service(service_name, urls, api_keys, api_version, stuck_metadata=Fa
             logging.debug(f"Skipping 'Import Failure' detection for {instance_name} (disabled).")
 
 if __name__ == "__main__":
-    try:
+    try:        
+        logging.info("Starting ArrStalledHandler")
+        log_env_vars()
         while True:
             initialize_database()
             services = [

--- a/main.py
+++ b/main.py
@@ -394,15 +394,15 @@ def handle_download(
         if elapsed_time > timeout:
             logging.info(
                 f"Handling stuck metadata download ID {download_id} in {service_name} "
-                f"(elapsed time: {elapsed_time} seconds)."
+                f"(elapsed time: {elapsed_time}/{timeout} seconds)."
             )
             perform_action(base_url, headers, download_id, movie_id, service_name, api_version, episode_ids)
             remove_stalled_download_from_db(download_id, service_name)
         else:
-            logging.info(f"Metadata download ID {download_id} in {service_name} is within timeout period ({elapsed_time} seconds).")
+            logging.info(f"Metadata download ID {download_id} in {service_name} is within timeout period ({elapsed_time}/{timeout} seconds).")
     else:
         add_stalled_download_to_db(download_id, now, service_name)
-        logging.info(f"Added metadata download ID {download_id} in {service_name} to the database.")
+        logging.info(f"Added metadata download ID {download_id} in {service_name} to the database. ({timeout}s timeout)")
 
 def process_service(service_name, urls, api_keys, api_version, stuck_metadata=False, detect_failed=False):
     if len(urls) != len(api_keys):

--- a/main.py
+++ b/main.py
@@ -310,14 +310,14 @@ def handle_stalled_downloads(base_url, api_key, service_name, api_version):
         is_import_failed_state = download_state == "importpending" and has_no_files_found
 
         if is_stalled_state or is_import_failed_state:
+
+            title = str(item.get("title") or "unknown").lower()
+            download_stall_reason = "failed import" if is_import_failed_state else "stalled"
+            logging.debug(f"Download '{title}' stalled due to: {download_stall_reason}.")
+
             download_id = str(item["id"])
             movie_id = item.get("movieId") if service_name == "Radarr" else None
-            episode_ids = [item["episodeId"]] if service_name == "Sonarr" and "episodeId" in item else None
-            
-            if is_import_failed_state:
-                download_stall_reason = "failed import"
-            else:
-                download_stall_reason = "stalled"
+            episode_ids = [item["episodeId"]] if service_name == "Sonarr" and "episodeId" in item else None            
 
             if download_id in stalled_downloads:
                 first_detected = stalled_downloads[download_id]

--- a/main.py
+++ b/main.py
@@ -171,7 +171,7 @@ def detect_failed_imports(base_url, api_key, service_name, api_version):
     # Query parameters for metadata detection
     params = {
         "protocol": "torrent",
-        "status": "complete",
+        "status": "completed",
         "includeEpisode": "true" if service_name == "Sonarr" else "false"
     }
 


### PR DESCRIPTION
Got tired of this constantly happening, this PR should now treat them as stalled and retry (Which if the download is a false early release, will then find nothing, ok) I could try figure out which tracker gives bad downloads, but this is the workaround in the short term.